### PR TITLE
feat: add View Responses button and URL filter for submissions

### DIFF
--- a/frontend/suggestion/src/__tests__/formspage.test.tsx
+++ b/frontend/suggestion/src/__tests__/formspage.test.tsx
@@ -132,4 +132,29 @@ describe('FormsPage', () => {
       expect(screen.getByText(/Failed to generate QR\./i)).toBeInTheDocument()
     })
   })
+
+  test('View Responses navigates to submissions with formId param', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        feedbackForms: [
+          {
+            _id: 'form-abc-123',
+            title: 'Feedback Form',
+            businessId: 'b1',
+            fields: [{ name: 'q', label: 'Question', type: 'short_text', required: false }],
+          },
+        ],
+      },
+    } as FormsListApiResponse)
+
+    renderFormsPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/Feedback Form/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /View Responses/i }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/submissions?formId=form-abc-123')
+  })
 })

--- a/frontend/suggestion/src/__tests__/submissions-page.test.tsx
+++ b/frontend/suggestion/src/__tests__/submissions-page.test.tsx
@@ -170,6 +170,27 @@ describe('SubmissionsPage', () => {
     })
   })
 
+  it('applies formId from URL and fetches submissions for that form', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: { feedbackForms: [{ _id: 'f-from-url', title: 'Form From URL' }] } })
+      .mockResolvedValueOnce({ data: { submissions: [], total: 0 } })
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard/submissions?formId=f-from-url']}>
+        <SubmissionsPage />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/No submissions found/i)).toBeInTheDocument()
+    })
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    const submissionsCall = mockedAxios.get.mock.calls.find((call) => String(call[0]).includes('submissions'))
+    expect(submissionsCall).toBeDefined()
+    expect(submissionsCall![0]).toMatch(/\?.*formId=f-from-url/)
+  })
+
   it('Previous/Next pagination buttons work', async () => {
     const manySubmissions = Array.from({ length: 20 }, (_, i) => ({
       _id: `sub-${i}`,

--- a/frontend/suggestion/src/pages/business-dashboard/pages/FormsPage.tsx
+++ b/frontend/suggestion/src/pages/business-dashboard/pages/FormsPage.tsx
@@ -108,13 +108,22 @@ export default function FormsPage() {
                 <p className="text-xs text-slate-500">Business ID: {form.businessId}</p>
                 {form.description ? <p className="mt-1 text-sm text-slate-600">{form.description}</p> : null}
               </div>
-              <button
-                type="button"
-                onClick={() => void handleGenerateQr(form._id)}
-                className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white"
-              >
-                Generate QR
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => navigate(`/dashboard/submissions?formId=${encodeURIComponent(form._id)}`)}
+                  className="rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+                >
+                  View Responses
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleGenerateQr(form._id)}
+                  className="rounded-lg bg-emerald-600 px-3 py-2 text-xs font-semibold text-white"
+                >
+                  Generate QR
+                </button>
+              </div>
             </div>
 
             <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Fields</p>

--- a/frontend/suggestion/src/pages/business-dashboard/pages/SubmissionsPage.tsx
+++ b/frontend/suggestion/src/pages/business-dashboard/pages/SubmissionsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import axios from 'axios'
 import { useAuth } from '../../../context/AuthContext'
 import { feedbackFormsApi, feedbackFormSubmissionsApi } from '../../../utils/apipath'
@@ -80,6 +81,9 @@ function ResponseDetailModal({
 }
 
 export default function SubmissionsPage() {
+  const [searchParams] = useSearchParams()
+  const formIdFromUrl = searchParams.get('formId') ?? ''
+
   const [forms, setForms] = useState<FeedbackForm[]>([])
   const [submissions, setSubmissions] = useState<Submission[]>([])
   const [total, setTotal] = useState(0)
@@ -87,14 +91,23 @@ export default function SubmissionsPage() {
   const [error, setError] = useState('')
   const [page, setPage] = useState(1)
   const [pageSize] = useState(20)
-  const [formId, setFormId] = useState('')
+  const [formId, setFormId] = useState(formIdFromUrl)
   const [dateFrom, setDateFrom] = useState('')
   const [dateTo, setDateTo] = useState('')
-  const [formIdApplied, setFormIdApplied] = useState('')
+  const [formIdApplied, setFormIdApplied] = useState(formIdFromUrl)
   const [dateFromApplied, setDateFromApplied] = useState('')
   const [dateToApplied, setDateToApplied] = useState('')
   const [viewSubmission, setViewSubmission] = useState<Submission | null>(null)
   const { getAuthHeaders } = useAuth()
+
+  // When URL formId changes (e.g. navigating from Saved Forms), sync filter and applied state
+  useEffect(() => {
+    if (formIdFromUrl) {
+      setFormId(formIdFromUrl)
+      setFormIdApplied(formIdFromUrl)
+      setPage(1)
+    }
+  }, [formIdFromUrl])
 
   const authHeaders = useMemo(
     () => ({


### PR DESCRIPTION
- Add View Responses button next to Generate QR on Saved Forms page
- Navigate to /dashboard/submissions?formId=<id> to show form responses
- SubmissionsPage reads formId from URL and applies filter on load
- Add tests for View Responses navigation and URL formId sync

Made-with: Cursor