### PR TITLE
Form validation: highlight invalid fields with red border, show errors per field

### DIFF
--- a/frontend/suggestion/src/__tests__/FormFieldRenderer.test.tsx
+++ b/frontend/suggestion/src/__tests__/FormFieldRenderer.test.tsx
@@ -75,6 +75,25 @@ describe('FormFieldRenderer', () => {
     expect(onChange).toHaveBeenCalledWith('email', 'a@b.com')
   })
 
+  test('passing error to short_text highlights the input and shows message', () => {
+    render(
+      <FormFieldRenderer
+        field={{
+          name: 'comment',
+          label: 'Comment',
+          type: 'short_text',
+          required: true,
+        }}
+        value=""
+        onChange={() => {}}
+        error="Comment is required."
+      />,
+    )
+    const input = screen.getByRole('textbox', { name: /Comment/i })
+    expect(input).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByText('Comment is required.')).toBeInTheDocument()
+  })
+
   test('renders big_text as Textarea', () => {
     render(
       <FormFieldRenderer

--- a/frontend/suggestion/src/__tests__/form-render-page.test.tsx
+++ b/frontend/suggestion/src/__tests__/form-render-page.test.tsx
@@ -128,7 +128,7 @@ describe('FormRenderPage', () => {
     })
   })
 
-  test('submit without required field shows validation error', async () => {
+  test('submit without required field shows validation error and highlights invalid field', async () => {
     mockedAxios.get.mockResolvedValueOnce({ data: mockFormConfig })
 
     renderFormRenderPage('form-1')
@@ -140,9 +140,11 @@ describe('FormRenderPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Submit/i }))
 
     await waitFor(() => {
-      expect(screen.getByText(/required/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/required/i).length).toBeGreaterThan(0)
     })
     expect(screen.getByRole('heading', { name: /Customer Feedback/i })).toBeInTheDocument()
+    const commentInput = screen.getByRole('textbox', { name: /Comment/i })
+    expect(commentInput).toHaveAttribute('aria-invalid', 'true')
   })
 
   test('shows error when formId is missing', async () => {
@@ -203,7 +205,7 @@ describe('FormRenderPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Submit/i }))
     await waitFor(() => {
-      expect(screen.getByText(/required/i)).toBeInTheDocument()
+      expect(screen.getAllByText(/required/i).length).toBeGreaterThan(0)
     })
 
     fireEvent.click(screen.getByRole('checkbox', { name: /Yes/i }))

--- a/frontend/suggestion/src/components/forms/field-types/BigTextField.tsx
+++ b/frontend/suggestion/src/components/forms/field-types/BigTextField.tsx
@@ -26,7 +26,7 @@ export default function BigTextField({
   error,
 }: BigTextFieldProps) {
   return (
-    <FieldWrapper id={id} label={label} error={error}>
+    <FieldWrapper id={id} label={label}>
       <Textarea
         id={id}
         value={value}
@@ -35,6 +35,7 @@ export default function BigTextField({
         rows={rows}
         required={required}
         disabled={disabled}
+        error={error}
       />
     </FieldWrapper>
   )

--- a/frontend/suggestion/src/components/forms/field-types/ShortTextField.tsx
+++ b/frontend/suggestion/src/components/forms/field-types/ShortTextField.tsx
@@ -24,7 +24,7 @@ export default function ShortTextField({
   error,
 }: ShortTextFieldProps) {
   return (
-    <FieldWrapper id={id} label={label} error={error}>
+    <FieldWrapper id={id} label={label}>
       <Input
         id={id}
         type="text"
@@ -33,6 +33,7 @@ export default function ShortTextField({
         placeholder={placeholder}
         required={required}
         disabled={disabled}
+        error={error}
       />
     </FieldWrapper>
   )

--- a/frontend/suggestion/src/components/ui/Input.tsx
+++ b/frontend/suggestion/src/components/ui/Input.tsx
@@ -17,7 +17,7 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
 const baseInputClasses =
   'w-full min-h-[44px] rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-base text-slate-900 outline-none transition focus:border-emerald-600 focus:ring-2 focus:ring-emerald-600/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-emerald-500 dark:focus:ring-emerald-500/30'
 const errorInputClasses =
-  'border-red-400 focus:border-red-500 focus:ring-2 focus:ring-red-200 dark:border-red-500 dark:focus:ring-red-500/30'
+  '!border-red-400 focus:!border-red-500 focus:ring-2 focus:ring-red-200 dark:!border-red-500 dark:focus:!border-red-500 dark:focus:ring-red-500/30'
 
 export default function Input({
   id,

--- a/frontend/suggestion/src/components/ui/Textarea.tsx
+++ b/frontend/suggestion/src/components/ui/Textarea.tsx
@@ -17,7 +17,7 @@ export interface TextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaE
 const baseClasses =
   'w-full min-h-[44px] rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-base text-slate-900 outline-none transition focus:border-emerald-600 focus:ring-2 focus:ring-emerald-600/20 resize-none dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-emerald-500 dark:focus:ring-emerald-500/30'
 const errorClasses =
-  'border-red-400 focus:border-red-500 focus:ring-2 focus:ring-red-200 dark:border-red-500 dark:focus:ring-red-500/30'
+  '!border-red-400 focus:!border-red-500 focus:ring-2 focus:ring-red-200 dark:!border-red-500 dark:focus:!border-red-500 dark:focus:ring-red-500/30'
 
 export default function Textarea({
   id,

--- a/frontend/suggestion/src/pages/feedback-form-render/FormRenderPage.tsx
+++ b/frontend/suggestion/src/pages/feedback-form-render/FormRenderPage.tsx
@@ -35,20 +35,21 @@ function getInitialValues(fields: FeedbackFormField[]): FormValues {
 function validateRequired(
   fields: FeedbackFormField[],
   values: FormValues
-): string | null {
+): Record<string, string> {
+  const errors: Record<string, string> = {}
   for (const field of fields) {
     if (!field.required) continue
     const v = values[field.name]
     if (field.type === 'checkbox') {
       const arr = Array.isArray(v) ? v : []
-      if (arr.length === 0) return `${field.label} is required.`
+      if (arr.length === 0) errors[field.name] = `${field.label} is required.`
     } else {
       if (v === undefined || v === '' || (typeof v === 'string' && !v.trim())) {
-        return `${field.label} is required.`
+        errors[field.name] = `${field.label} is required.`
       }
     }
   }
-  return null
+  return errors
 }
 
 function buildSubmitPayload(
@@ -85,6 +86,7 @@ export default function FormRenderPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [values, setValues] = useState<FormValues>({})
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitted, setSubmitted] = useState(false)
   const [submitting, setSubmitting] = useState(false)
@@ -125,6 +127,11 @@ export default function FormRenderPage() {
 
   const updateValue = useCallback((name: string, value: string | string[] | File | undefined) => {
     setValues((prev) => ({ ...prev, [name]: value }))
+    setFieldErrors((prev) => {
+      const next = { ...prev }
+      delete next[name]
+      return next
+    })
     setSubmitError(null)
   }, [])
 
@@ -132,11 +139,14 @@ export default function FormRenderPage() {
     async (e: React.FormEvent) => {
       e.preventDefault()
       if (!config || !formId) return
-      const requiredError = validateRequired(config.fields, values)
-      if (requiredError) {
-        setSubmitError(requiredError)
+      const errors = validateRequired(config.fields, values)
+      const hasErrors = Object.keys(errors).length > 0
+      if (hasErrors) {
+        setFieldErrors(errors)
+        setSubmitError(null)
         return
       }
+      setFieldErrors({})
       setSubmitError(null)
       setSubmitting(true)
       try {
@@ -231,10 +241,11 @@ export default function FormRenderPage() {
             field={field as FormFieldConfig}
             value={values[field.name]}
             onChange={updateValue}
+            error={fieldErrors[field.name]}
           />
         ))}
 
-        {submitError ? (
+        {submitError && Object.keys(fieldErrors).length === 0 ? (
           <ErrorMessage message={submitError} />
         ) : null}
 


### PR DESCRIPTION
- FormRenderPage: validate to field-level errors (Record), pass error to FormFieldRenderer, clear on change
- ShortTextField/BigTextField: pass error to Input/Textarea for red border and message
- Input/Textarea: use !important border classes so error state overrides default
- Only show bottom error block for server errors, not validation (avoids misplaced message)
- Tests: FormFieldRenderer error prop, form-render validation and aria-invalid
