### PR TITLE
feat(backend): run typecheck in lint and add typecheck scripts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,7 @@
+# Backend API
+
+## Scripts
+
+- **`npm run lint`** – Runs ESLint and TypeScript type-check on production source (`src/`, excluding `__tests__` and `scripts/`). Use this before pushing to catch type and assignability issues in app code.
+- **`npm run typecheck`** – Full TypeScript check including test files. Run this (e.g. in CI) to catch type errors in tests too (e.g. mock request/response not assignable to Express types; use `as unknown as Request`-style casts in tests when needed).
+- **`npm run typecheck:src`** – Type-check production code only (same as the check run by `lint`).

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
     "test:business": "jest --testPathPattern=business.test",
     "test:r2": "jest --runInBand --testPathPattern=src/__tests__/r2.test.ts",
     "seed:admin": "ts-node src/scripts/seed-admin.ts",
-    "lint": "eslint src"
+    "lint": "eslint src && npm run typecheck:src",
+    "typecheck": "tsc --noEmit",
+    "typecheck:src": "tsc --noEmit -p tsconfig.lint.json"
   },
   "keywords": [],
   "author": "",

--- a/backend/tsconfig.lint.json
+++ b/backend/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/__tests__/**", "src/scripts/**"]
+}


### PR DESCRIPTION
- lint: eslint + typecheck:src (production code only via tsconfig.lint.json)
- typecheck: full tsc --noEmit for CI / test file type errors
- tsconfig.lint.json: excludes __tests__ and scripts so lint stays green
- backend/README.md: document lint, typecheck, typecheck:src

Made-with: Cursor